### PR TITLE
Initial modifications for threading:

### DIFF
--- a/src/ProcessReads.cpp
+++ b/src/ProcessReads.cpp
@@ -179,24 +179,12 @@ int ProcessReads(KmerIndex& index, const ProgramOptions& opt, MinCollector& tc) 
 
   if (MP.output_handler.enhancedoutput) {
 
-	  std::cerr << "get sam time: " << MP.output_handler.get_sam_time.count() << " sec" << std::endl;
-	  std::cerr << "out align time: " << MP.output_handler.out_align_time.count() << " sec" << std::endl;
-	  std::cerr << "total output time: " << MP.output_handler.output_time.count() << " sec" << std::endl;
-
 	  // Output sorted BAM
 
 	  if (MP.output_handler.sortedbam) {
-
 		  std::cerr << "sorting bam output ..."; std::cerr.flush();
-
 		  MP.output_handler.outputSortedBam();
-
 		  std::cerr << " done" << std::endl;
-
-		  std::cerr << "pre sort time: " << MP.output_handler.pre_sort_time.count() << " sec" << std::endl;
-		  std::cerr << "sort time: " << MP.output_handler.sort_time.count() << " sec" << std::endl;
-		  std::cerr << "post sort time: " << MP.output_handler.post_sort_time.count() << " sec" << std::endl;
-
 	  }
 
 	  // Output junction BED
@@ -278,7 +266,7 @@ void MasterProcessor::processReads() {
   if (!opt.batch_mode) {
     std::vector<std::thread> workers;
     for (int i = 0; i < opt.threads; i++) {
-      workers.emplace_back(std::thread(ReadProcessor(index,opt,tc,*this)));
+      workers.emplace_back(std::thread(ReadProcessor(index,opt,tc,*this,i)));
     }
     
     // let the workers do their thing
@@ -792,12 +780,12 @@ void ReadProcessor::processBuffer() {
         outputPseudoBam(index, u,
           s1, names[i-1].first, quals[i-1].first, l1, names[i-1].second, v1,
           s2, names[i].first, quals[i].first, l2, names[i].second, v2,
-          paired, mp.output_handler);
+          paired, mp.output_handler, id);
       } else {
 		  outputPseudoBam(index, u,
 			  s1, names[i].first, quals[i].first, l1, names[i].second, v1,
 			  nullptr, nullptr, nullptr, 0, 0, v2,
-			  paired, mp.output_handler);
+			  paired, mp.output_handler, id);
       }
     }
 

--- a/src/ProcessReads.h
+++ b/src/ProcessReads.h
@@ -70,8 +70,9 @@ public:
 class MasterProcessor {
 public:
   MasterProcessor (KmerIndex &index, const ProgramOptions& opt, MinCollector &tc)
-    : tc(tc), index(index), opt(opt), SR(opt), numreads(0)
-    ,nummapped(0), num_umi(0), tlencount(0), biasCount(0), maxBiasCount((opt.bias) ? 1000000 : 0) { 
+    : tc(tc), index(index), opt(opt), SR(opt), numreads(0),
+      nummapped(0), num_umi(0), tlencount(0), biasCount(0), maxBiasCount((opt.bias) ? 1000000 : 0),
+	  output_handler(index, opt) { 
       if (opt.batch_mode) {
         batchCounts.resize(opt.batch_ids.size(), {});
         
@@ -87,10 +88,6 @@ public:
         ofusion.open(opt.output + "/fusion.txt");
         ofusion << "TYPE\tNAME1\tSEQ1\tKPOS1\tNAME2\tSEQ2\tKPOS2\tINFO\tPOS1\tPOS2\n";
       }
-
-	  // Initialize enhanced output object
-	  output_handler = EnhancedOutput(index, opt);
-
     }
 
   std::mutex reader_lock;

--- a/src/PseudoBam.h
+++ b/src/PseudoBam.h
@@ -9,6 +9,6 @@
 void outputPseudoBam(const KmerIndex &index, const std::vector<int> &u,
                     const char *s1, const char *n1, const char *q1, int slen1, int nlen1, const std::vector<std::pair<KmerEntry,int>>& v1,
                     const char *s2, const char *n2, const char *q2, int slen2, int nlen2, const std::vector<std::pair<KmerEntry,int>>& v2,
-					bool paired, EnhancedOutput &output_handler);
+					bool paired, EnhancedOutput &output_handler, int id);
 void revseq(char *b1, char *b2, const char *s, const char *q, int n);
 void getCIGARandSoftClip(char* cig, bool strand, bool mapped, int &posread, int &posmate, int length, int targetlength);

--- a/src/enhancedoutput.h
+++ b/src/enhancedoutput.h
@@ -112,20 +112,13 @@ public:
 	std::map<JunctionKey, std::tuple<std::string, int, char, int, int, int, int>> junction_map;
 
 	// Temporary and buffer storage for mapping reads and BAM output
-	std::set<std::string> gene_list;
-	std::vector<uint> bam_cigar;
-	uint align_len;
 	char outBamBuffer[MAX_BAM_ALIGN_SIZE];
 
-	// Timing variables
-	HighResTimer timer;
-	HighResTimer::duration get_sam_time, out_align_time, output_time;
-	HighResTimer::duration pre_sort_time, sort_time, post_sort_time;
-
-	bool getSamData(std::string &ref_name, char *cig, int& strand, bool mapped, int &posread, int &posmate, int slen1, int slen2);
-	void buildCigar(std::string &cig_string, bool prepend, uint op_len, const char cig_char, uint cig_int);
+	void processAlignment(std::string &ref_name, int& strand, int &posread, int &posmate, int slen1, int slen2, char *cig, std::vector<uint> &bam_cigar, uint &align_len);
+	void buildSAMCigar(std::string &cig_string, bool prepend, uint op_len, const char cig_char);
+	void buildBAMCigar(std::vector<uint> &bam_cigar, uint &align_len, bool prepend, uint op_len, uint cig_int);
 	void mapJunction(std::string chrom_name, std::string trans_name, bool negstrand, int start_coord, int end_coord, int size1, int size2, int pair_start, int pair_end);
-	void outputBamAlignment(std::string ref_name, int posread, int flag, int slen, int posmate, int tlen, const char *n1, const char *seq, const char *qual, int nmap, int strand);
+	void outputBamAlignment(std::string ref_name, int posread, int flag, int slen, int posmate, int tlen, const char *n1, std::vector<uint> bam_cigar, uint align_len, const char *seq, const char *qual, int nmap, int strand, int id);
 	void outputSortedBam();
 
 	static int reg2bin(int beg, int end);


### PR DESCRIPTION
 - Removed timing variables for now.
 - Used ReadProcessor id argument to identify threads (meaning that batch mode can't be used with multi-threaded sorted BAM output).
 - Moved removal of repeated gene mappings to before they are looped over.
 - Moved some temporary storage variables from EnhancedOutput class members to local variables.
 - Split buildCigar into buildBAMCigar and buildSAMCigar.